### PR TITLE
add handling for re-running on the same day

### DIFF
--- a/tools/issues.sh
+++ b/tools/issues.sh
@@ -31,7 +31,12 @@ fi
 
 DEST_DIR_PREFIX="$DEST_DIR/$(date "+%Y-%m-%d")"
 
-mkdir "$DEST_DIR_PREFIX"
+if [ -d $DEST_DIR_PREFIX ]
+then
+  echo "Folder exists at ${DEST_DIR_PREFIX}"
+else
+  mkdir "$DEST_DIR_PREFIX"
+fi
 
 if [ $? != 0 ]; then
   echo "Unable to create ${DEST_DIR_PREFIX}. Exiting"
@@ -46,6 +51,17 @@ do
 
   if [ -f "${SRC}" ]
   then
+    if [ -f "${DEST}" ]
+    then
+      read -r -p "${source_file%.txt} exists. Overwrite? [y/N]" response
+      if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
+      then
+        continue
+      else
+        echo -n > "${DEST}"
+      fi
+    fi
+
     printf "%s " "${source_file%.txt}"
     process_sourcefile "${SRC}" "${DEST}"
     printf "%s\n" "$(wc -l "${DEST}" |awk '{print $1}')"


### PR DESCRIPTION
Ran into rate limit half-way through when I ran the script. Since some of the tracks were already checked, I rewrote the script to handle a being rerun on the same day, ignoring if the day's folder exists and giving the option to skip over track checks that are already done